### PR TITLE
Implement reset last submission

### DIFF
--- a/src/views/Dashboard/index.vue
+++ b/src/views/Dashboard/index.vue
@@ -11,7 +11,39 @@
         >
           <v-icon>mdi-autorenew</v-icon>
         </v-btn>
+        <v-btn class="white--text primary" @click="resetDialog = true"
+          >Reset Last Submission</v-btn
+        >
       </h1>
+      <div class="text-center">
+        <v-dialog v-model="resetDialog" width="500">
+          <v-card>
+            <v-card-title class="white--text headline primary py-3 pl-5"
+              >Warning</v-card-title
+            >
+
+            <v-card-text class="mt-5">
+              Resetting your last submission is computationally intensive. Click
+              reset last submission if you wish to proceed.
+            </v-card-text>
+
+            <v-divider></v-divider>
+
+            <v-card-actions>
+              <v-spacer></v-spacer>
+              <v-btn
+                :loading="resetLoading"
+                class="primary"
+                @click="resetLastSubmission()"
+                >Reset Last Submission</v-btn
+              >
+              <v-btn text @click="resetDialog = false" class="primary--text"
+                >Cancel</v-btn
+              >
+            </v-card-actions>
+          </v-card>
+        </v-dialog>
+      </div>
       <v-row v-if="problemSets.length == 0">
         <v-col cols="12" class="primary--text title"
           >No tracked problem sets yet</v-col
@@ -57,7 +89,9 @@ export default {
   data: () => {
     return {
       problemSets: [],
-      refreshLoading: false
+      refreshLoading: false,
+      resetLoading: false,
+      resetDialog: false
     };
   },
 
@@ -85,6 +119,21 @@ export default {
 
       eventBus.$emit("REFRESH_USERS_SUCCESS");
       this.refreshLoading = false;
+    },
+
+    async resetLastSubmission() {
+      this.resetLoading = true;
+      const { data } = await api.patch(
+        `/users/${this.$store.state.user._id}/resetLastSubmission`,
+        {
+          headers: {
+            Authorization: this.$store.state.token
+          }
+        }
+      );
+      this.$store.dispatch("setUser", data);
+      this.resetLoading = false;
+      this.resetDialog = false;
     }
   }
 };


### PR DESCRIPTION
Adds a button to the dashboard that calls the new users/:userId/resetLastSubmission route in order reset the users last submission in turn forcing the API to refresh the users information from codeforces. Part of issue: https://github.com/Compete-McGill/wisp/issues/41