### PR TITLE
feat: replace wisp-prod with secrets.GKE_CLUSTER

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -12,7 +12,7 @@ env:
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   DOCKER_ORGANIZATION: ${{ secrets.DOCKER_ORGANIZATION }} 
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
-  GKE_CLUSTER: wisp-prod
+  GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
   GKE_ZONE: northamerica-northeast1-c
   IMAGE: wisp-ui
 

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -13,7 +13,7 @@ env:
   DOCKER_ORGANIZATION: ${{ secrets.DOCKER_ORGANIZATION }} 
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
   GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
-  GKE_ZONE: northamerica-northeast1-c
+  GKE_ZONE: ${{ secrets.GKE_ZONE }}
   IMAGE: wisp-ui
 
 jobs:

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -12,7 +12,7 @@ env:
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   DOCKER_ORGANIZATION: ${{ secrets.DOCKER_ORGANIZATION }} 
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
-  GKE_CLUSTER: wisp-prod
+  GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
   GKE_ZONE: northamerica-northeast1-c
   IMAGE: wisp-ui
 

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -13,7 +13,7 @@ env:
   DOCKER_ORGANIZATION: ${{ secrets.DOCKER_ORGANIZATION }} 
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
   GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
-  GKE_ZONE: northamerica-northeast1-c
+  GKE_ZONE: ${{ secrets.GKE_ZONE }}
   IMAGE: wisp-ui
 
 jobs:


### PR DESCRIPTION
This makes the GKE_CLUSTER name in the dev and prod github workflows more configurable by setting it through a github secret.